### PR TITLE
add following the system's preference and localStorage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install with yarn
 yarn add react-darkreader
 ```
 
-Or you can
+Or
 
 ```bash
 npm install react-darkreader
@@ -36,7 +36,7 @@ Or inject the script at your page by [jsdelivr CDN](https://www.jsdelivr.com/)
 
 ## 🚀 Usage
 
-You can import the darkmode as a react component.
+For a simple light/dark switch, darkreader can be used as a component:
 
 ```tsx | pure
 import React from 'react';
@@ -45,16 +45,22 @@ import Darkreader from 'react-darkreader';
 export default () => <Darkreader />;
 ```
 
-You can also create darkmode by the react hook `useDarkreader`
+For a custom switch and/or following the system's preference, you can use the `useDarkreader` hook.
 
 ```tsx | pure
 import React from 'react';
-import { Switch, useDarkreader } from 'react-darkreader';
+import { useDarkreader } from 'react-darkreader';
 
 export default () => {
-  const [isDark, { toggle }] = useDarkreader(false);
+  const [isDark, { toggle }, mode] = useDarkreader(false);
 
-  return <Switch checked={isDark} onChange={toggle} />;
+  return (
+    <>
+      <CustomSwitch mode={mode} onChange={toggle} />
+      <p>Current mode: {mode}</p>
+      <p>Is dark: {isDark}</p>
+    </>
+  );
 };
 ```
 
@@ -75,63 +81,54 @@ export default () => {
 
 ### Hook
 
-```typescript | pure
-const [isDark, { toggle, collectCSS }] = useDarkreader(defaultDarken, theme?, fixes?)
+```typescript
+const [isDark, { toggle, setMode, collectCSS }, mode] = useDarkreader(
+  defaultDarken,
+  theme?,
+  fixes?,
+  allowSystem,
+);
 ```
 
-with a toggle button as ui.
+### Hook Result
 
-```tsx | pure
-<Switch checked={isDark} onChange={toggle} />
-```
+| Return Value | Description                                             | Type                              |
+| ------------ | ------------------------------------------------------- | --------------------------------- |
+| `isDark`     | Whether the current mode is dark.                       | `boolean`                         |
+| `action`     | Object containing darkmode control methods.             | `{ toggle, setMode, collectCSS }` |
+| `mode`       | Current mode value: `'light'`, `'dark'`, or `'system'`. | `'light' \| 'dark' \| 'system'`   |
 
-### Result
+#### `action` methods
 
-| Params     | Description                                             | Type                          |
-| ---------- | ------------------------------------------------------- | ----------------------------- |
-| isDark     | The status of current darkmode, support `true`, `false` | `boolean`                     |
-| toggle     | The function for toggling the darkmode.                 | `() => void`                  |
-| collectCSS | The async function for collecting the css of darkmode.  | `async () => Promise<string>` |
+| Method       | Description                                              | Type                    |
+| ------------ | -------------------------------------------------------- | ----------------------- |
+| `toggle`     | Cycle through modes (`light → dark → (system) → light`). | `() => void`            |
+| `setMode`    | Manually set mode (`'light'`, `'dark'`, `'system'`).     | `(mode: Mode) => void`  |
+| `collectCSS` | Collect generated darkmode CSS asynchronously.           | `() => Promise<string>` |
 
-### Params
+### Parameters
 
-| Params        | Description                                                                                                                                                                   | Type              | Default |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- | ------- |
-| defaultDarken | The default status of the darkreader                                                                                                                                          | `boolean`         | false   |
-| theme         | The options of darkreader Theme [refered to index.d.ts &rarr;](https://github.com/darkreader/darkreader/blob/13c93a995cde0b933580174106897bb1d13f53b4/index.d.ts#L41)         | `Partial<Theme>`  | -       |
-| fixes         | Contains fixes for the generated theme [refered to index.d.ts &rarr;](https://github.com/darkreader/darkreader/blob/13c93a995cde0b933580174106897bb1d13f53b4/index.d.ts#L121) | `DynamicThemeFix` | -       |
+| Param           | Description                                                                                                  | Type              | Default |
+| --------------- | ------------------------------------------------------------------------------------------------------------ | ----------------- | ------- |
+| `defaultDarken` | Initial darkmode status.                                                                                     | `boolean`         | `false` |
+| `theme`         | Darkreader theme overrides. [Reference →](https://github.com/darkreader/darkreader/blob/main/index.d.ts#L41) | `Partial<Theme>`  | -       |
+| `fixes`         | Fixes for generated theme. [Reference →](https://github.com/darkreader/darkreader/blob/main/index.d.ts#L121) | `DynamicThemeFix` | -       |
+| `allowSystem`   | Whether to allow system color scheme (`prefers-color-scheme`) support.                                       | `boolean`         | `false` |
 
 ## 🔢 Coming Soon
 
-- [x] add the material design styling in switch
-- [ ] followSystemColorScheme
-- [ ] localstorge
-- [ ] playground for editing the config online
+- [x] Material design switch UI
+- [x] `followSystemColorScheme`
+- [x] `localStorage` persistence
+- [ ] Online playground for theme config
 
 ## 🔨 Contribute
 
-Install dependencies,
-
 ```bash
-$ npm i
-```
-
-Start the dev server,
-
-```bash
-$ npm start
-```
-
-Build documentation,
-
-```bash
-$ npm run docs:build
-```
-
-Build library via `father-build`,
-
-```bash
-$ npm run build
+npm i
+npm start      # Start dev server
+npm run build  # Build library
+npm run docs:build
 ```
 
 ## 🥇 Who is using

--- a/src/useDarkreader.ts
+++ b/src/useDarkreader.ts
@@ -1,65 +1,123 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  enable as enableDarkMode,
-  disable as disableDarkMode,
   auto as followSystemColorScheme,
+  disable as disableDarkMode,
+  DynamicThemeFix,
+  enable as enableDarkMode,
   exportGeneratedCSS as collectCSS,
   setFetchMethod,
   Theme,
-  DynamicThemeFix,
 } from 'darkreader';
-import { Result } from 'antd';
+
+export type Mode = 'system' | 'light' | 'dark';
 
 export type Action = {
+  setMode: (mode: Mode) => void;
   toggle: () => void;
   collectCSS: () => Promise<string>;
 };
 
-export type Result = [boolean, Action];
+export type Result = [boolean, Action, Mode];
+
+const defaultTheme = {
+  brightness: 100,
+  contrast: 90,
+  sepia: 10,
+};
+
+const defaultFixes = {
+  invert: [],
+  css: '',
+  ignoreInlineStyle: ['.react-switch-handle'],
+  ignoreImageAnalysis: [],
+};
+
+const isValidMode = (value: string | null): value is Mode => {
+  return value === 'system' || value === 'light' || value === 'dark';
+};
 
 export default function useDarkreader(
   defaultDarken: boolean = false,
   theme?: Partial<Theme>,
   fixes?: DynamicThemeFix,
+  allowSystem: boolean = true,
 ): Result {
-  const [isDark, setIsDark] = useState(defaultDarken);
+  const STORAGE_KEY = 'darkreader-mode';
 
-  const defaultTheme = {
-    brightness: 100,
-    contrast: 90,
-    sepia: 10,
+  const getInitialMode = (): Mode => {
+    const storedValue = localStorage.getItem(STORAGE_KEY);
+    if (isValidMode(storedValue)) {
+      if (storedValue === 'system' && !allowSystem) {
+        return defaultDarken ? 'dark' : 'light';
+      }
+      return storedValue;
+    }
+    return allowSystem ? 'system' : defaultDarken ? 'dark' : 'light';
   };
 
-  const defaultFixes = {
-    invert: [],
-    css: '',
-    ignoreInlineStyle: ['.react-switch-handle'],
-    ignoreImageAnalysis: [],
-  };
+  const [mode, setMode] = useState<Mode>(getInitialMode);
+
+  const isDark =
+    mode === 'dark' ||
+    (mode === 'system' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches);
 
   useEffect(() => {
     setFetchMethod(window.fetch);
 
-    isDark
-      ? enableDarkMode(
+    if (mode === 'system' && !allowSystem) {
+      setMode(defaultDarken ? 'dark' : 'light');
+      return;
+    }
+
+    const applyMode = (selectedMode: Mode) => {
+      if (selectedMode === 'system' && allowSystem) {
+        followSystemColorScheme(
           { ...defaultTheme, ...theme },
           { ...defaultFixes, ...fixes },
-        )
-      : disableDarkMode();
-
-    // unmount
-    return () => {
-      disableDarkMode();
+        );
+      } else if (selectedMode === 'dark') {
+        enableDarkMode(
+          { ...defaultTheme, ...theme },
+          { ...defaultFixes, ...fixes },
+        );
+      } else {
+        disableDarkMode();
+      }
     };
 
-    // TODO: followSystemColorScheme();
-  }, [isDark]);
+    applyMode(mode);
+    localStorage.setItem(STORAGE_KEY, mode);
 
-  const action = useMemo(() => {
-    const toggle = () => setIsDark(prevState => !prevState);
+    if (mode === 'system' && allowSystem) {
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+      const handleChange = () => {
+        applyMode('system');
+      };
+      mediaQuery.addEventListener('change', handleChange);
 
-    return { toggle, collectCSS };
-  }, [isDark]);
+      return () => {
+        mediaQuery.removeEventListener('change', handleChange);
+      };
+    }
+  }, [mode, allowSystem]);
 
-  return [isDark, action];
+  const action = useMemo<Action>(() => {
+    const toggle = () => {
+      setMode(prev => {
+        if (prev === 'light') return 'dark';
+        if (prev === 'dark') return allowSystem ? 'system' : 'light';
+        return 'light';
+      });
+    };
+
+    const setModeAndStore = (newMode: Mode) => {
+      if (newMode === 'system' && !allowSystem) return;
+      setMode(newMode);
+    };
+
+    return { toggle, setMode: setModeAndStore, collectCSS };
+  }, [allowSystem]);
+
+  return [isDark, action, mode];
 }

--- a/src/useDarkreader.ts
+++ b/src/useDarkreader.ts
@@ -61,23 +61,11 @@ export default function useDarkreader(
 
   const [mode, setMode] = useState<Mode>(getInitialMode);
 
-  const [systemDark, setSystemDark] = useState(
-    typeof window !== 'undefined'
-      ? window.matchMedia('(prefers-color-scheme: dark)').matches
-      : defaultDarken,
-  );
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-
-    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
-    mq.addEventListener('change', handler);
-
-    return () => mq.removeEventListener('change', handler);
-  }, []);
-
-  const isDark = mode === 'dark' || (mode === 'system' && systemDark);
+  const isDark =
+    mode === 'dark' ||
+    (mode === 'system' &&
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
@@ -98,6 +86,10 @@ export default function useDarkreader(
     }
 
     const applyMode = (selectedMode: Mode) => {
+      if (selectedMode !== 'system') {
+        followSystemColorScheme(false);
+      }
+
       if (selectedMode === 'system' && allowSystem) {
         followSystemColorScheme(
           { ...defaultTheme, ...theme },

--- a/src/useDarkreader.ts
+++ b/src/useDarkreader.ts
@@ -40,7 +40,7 @@ export default function useDarkreader(
   defaultDarken: boolean = false,
   theme?: Partial<Theme>,
   fixes?: DynamicThemeFix,
-  allowSystem: boolean = true,
+  allowSystem: boolean = false,
 ): Result {
   const STORAGE_KEY = 'darkreader-mode';
 


### PR DESCRIPTION
This PR contains the following:

- Added support for 'system' color scheme detection (can be turned off/on)
- Persisted user mode preference (light, dark, system) via localStorage
- Introduced setMode action alongside toggle and collectCSS for manual mode setting
- Improved hook return type and cleanup logic
- Updated README to reflect new API and behavior
- SSR guards (window is undefined with SSR)

Note that:
- The demos were not updated
- The Darkreader and Switch components were not updated
- They are still functional due to allowSystem being false by default
--> Following the system's scheme is currently only possible via the hook